### PR TITLE
Fix report info_text for functions w/ multiple non-string args

### DIFF
--- a/energyusage/report.py
+++ b/energyusage/report.py
@@ -348,8 +348,11 @@ def generate(location, watt_averages, breakdown, kwh_and_emissions, func_info, \
         else:
             info_text += " with the inputs "
             for arg in func_args:
-                info_text += arg + ","
-            info_text = info_text[len(info_text)-1] + "."
+                if hasattr(arg, 'shape'):
+                    info_text += "arr" + str(arg.shape) + ", "
+                else:
+                    info_text += str(arg) + ", "
+            info_text = info_text[:-2] + "."
     else:
         info_text += "."
 


### PR DESCRIPTION
Passing a function with multiple arguments to `energyusage.evaluate()` causes an error if any args are not strings:
```
numpy.core._exceptions.UFuncTypeError: ufunc 'add' did not contain a loop with signature matching types (dtype('<U32'), dtype('<U32')) -> dtype('<U32')
```

Fixed report generation by casting each arg to string, as well as improving formatting for `np.ndarray` arg types 💪