### PR TITLE
correct error in valid_gpu()

### DIFF
--- a/energyusage/evaluate.py
+++ b/energyusage/evaluate.py
@@ -8,11 +8,11 @@ import subprocess
 import queue
 import csv
 
-import utils as utils
-import convert as convert
-import locate as locate
-import report as report
-import graph
+from . import utils as utils
+from . import convert as convert
+from . import locate as locate
+from . import report as report
+from . import graph
 
 DELAY = .1 # in seconds
 
@@ -147,11 +147,6 @@ def energy(user_func, *args, powerLoss = 0.8, year, printToScreen, timeseries):
 
     # Subtracting baseline wattage to get more accurate result
     process_kwh = convert.to_kwh((process_average - baseline_average)*total_time) / powerLoss
-
-    if is_nvidia_gpu:
-        gpu_file = file("GPU", "")
-        gpu_file.create_gpu(gpu_baseline_average, gpu_process_average)
-        files.append(file("GPU", ""))
 
     # Logging
     if printToScreen:

--- a/energyusage/report.py
+++ b/energyusage/report.py
@@ -10,8 +10,8 @@ from reportlab.graphics.charts.barcharts import VerticalBarChart
 from reportlab.graphics.charts.textlabels import Label
 
 import energyusage.convert as convert
-import evaluate as evaluate
-import locate
+from . import evaluate as evaluate
+from . import locate
 
 import math
 

--- a/energyusage/utils.py
+++ b/energyusage/utils.py
@@ -300,6 +300,6 @@ def valid_gpu():
     try:
         bash_command = "nvidia-smi > /dev/null 2>&1" #we must pipe to ignore error message
         output = subprocess.check_call(['bash', '-c', bash_command])
-        return isinstance(output, float) # directly return a boolean
+        return isinstance(output, int) # directly return a boolean
     except:
         return False


### PR DESCRIPTION
As indicated in Issue  #14, there is an issue with the valid_gpu() function. subprocess.check_call() returns an integer (return code) and not a float as tested. This results in valid_gpu() always returning False. Fixing this error triggers an error "'RAPLFile' object is not callable" when creating RAPL files with GPU logs. I removed this section.
I had trouble importing the module so I also changed the imports syntax.